### PR TITLE
코드 추가

### DIFF
--- a/rest-web/src/main/java/com/community/rest/domain/Board.java
+++ b/rest-web/src/main/java/com/community/rest/domain/Board.java
@@ -55,6 +55,7 @@ public class Board implements Serializable {
     private LocalDateTime updatedDate;
 
     @OneToOne
+    @JoinColumn(name = "user_id", referencedColumnName="idx")
     private User user;
 
     @Builder


### PR DESCRIPTION
해당 코드를 넣지 추가하지 않고 rest-web을 실행시킬 경우 
java.sql.SQLSyntaxErrorException: Unknown column 'board0_.user_idx' in 'field list' 에러가 발생했습니다.
해당 에러를 고치기 위해 https://www.baeldung.com/jpa-one-to-one 의 3.2 부분을 참고하였습니다.